### PR TITLE
Add standardized point cloud time processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # libpointmatcher_ros
-A bridge between libpointmatcher and ROS
+A bridge between libpointmatcher and ROS, converts between [ROS point cloud messages](https://docs.ros.org/en/jade/api/sensor_msgs/html/msg/PointCloud2.html) and libpointmatcher `DataPoints` objects.
+While the conversion of most datafields is straightforward, the per-point time field if more complicated due to different manufactures/driver authors represent timestamp messages.
+In this driver, we distinguish between three types of timestamps:
+
+| Name         | Tested on                     | Datatype | ROS PointField | Stamped with |
+|--------------|-------------------------------|----------|----------------|--------------|
+| Ouster-like  | RS-32                         | uint32   | 6              | beginning    |
+| Leishen-like | LS L128 S1                    | float32  | 7              | end          |
+| Hesai-like   | RS Ruby Plus, Hesai Pandar XT | float64  | 8              | beginning    |
+
+Inside libpointmatcher, all timestamps are represented in a field called `time` as `int64` datatypes.
+This usually represent a timestamp in epoch time in [ns].
+However, when converting from `DataPoints` to ROS messages, the timestamp needs to be split as the ROS messages don't support `int64` timestamps.
+The timestamp is therefore split into two fields: `time_splitTime_high32` and `time__splitTime_low32`, representing the high and low 32 bits of the timestamp, respectively.
+You won't typically see any differences between points when using the higher 32 bits of the timestamp, so use the lower 32 bits for any visualization purposes.
+Moreover, `libpointmatcher_ros` also outputs an additional field called `elapsedTimeSec`, which represents the time elapsed between the first and the last point in the point cloud (with a lidar at 10 Hz, the values will lie between 0.0 to 0.1 seconds).
+When converting back from ROS messages to `DataPoints`, the low and high fields get combined back into a single `int64` timestamp.
+
+Below you can find a brief explication how the different timestamp types are treated when converted to `DataPoints` objects.
+
+### Ouster-like
+For Ouster-like timestamps, the timestamp is stored in the `uint32` field `t` in the ROS message.
+The values represent the number of nanoseconds since the beginning of the scan, which is given in the `header.stamp` field.
+To get a per-point timestamp, one has to add the per-point `t` value to the value obtained from the `header.stamp` field.
+
+### Leishen-like
+For Leishen-like timestamps, the timestamp is stored in the `float` field `time` in the ROS message.
+The values represent the number of seconds (typically between 0.0 and 0.1) before the end of the scan, which is given in the `header.stamp` field.
+To get a per-point timestamp, we have to subtract the per-point `time` value from the value obtained from the `header.stamp` field.
+
+### Hesai-like
+For Hesai-like timestamps, the timestamp is stored in the `double` field `timestamp` in the ROS message.
+The values represent the number of seconds in epoch time.
+This is the easest case as the timestamp is already in a 8-byte representation and we just need to multiply the per-point `timestamp` value by 1e9 to obtain nanoseconds and convert it to an `int64` datatype.
+
+----------------
+Note that we haven't tested the bridge with different lidars, which might need special treatment due to different timestamp representations.
+To figure out how what exactly your ROS messages represent, you will need to investigate the driver code or the datasheet of the lidar.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # libpointmatcher_ros
+
 A bridge between libpointmatcher and ROS, converts between [ROS point cloud messages](https://docs.ros.org/en/jade/api/sensor_msgs/html/msg/PointCloud2.html) and libpointmatcher `DataPoints` objects.
 While the conversion of most datafields is straightforward, the per-point time field if more complicated due to different manufactures/driver authors represent timestamp messages.
 In this driver, we distinguish between three types of timestamps:
 
 | Name         | Tested on                     | Datatype | ROS PointField | Stamped with |
-|--------------|-------------------------------|----------|----------------|--------------|
+| ------------ | ----------------------------- | -------- | -------------- | ------------ |
 | Ouster-like  | RS-32                         | uint32   | 6              | beginning    |
 | Leishen-like | LS L128 S1                    | float32  | 7              | end          |
 | Hesai-like   | RS Ruby Plus, Hesai Pandar XT | float64  | 8              | beginning    |
@@ -20,20 +21,24 @@ When converting back from ROS messages to `DataPoints`, the low and high fields 
 Below you can find a brief explication how the different timestamp types are treated when converted to `DataPoints` objects.
 
 ### Ouster-like
+
 For Ouster-like timestamps, the timestamp is stored in the `uint32` field `t` in the ROS message.
 The values represent the number of nanoseconds since the beginning of the scan, which is given in the `header.stamp` field.
 To get a per-point timestamp, one has to add the per-point `t` value to the value obtained from the `header.stamp` field.
 
 ### Leishen-like
+
 For Leishen-like timestamps, the timestamp is stored in the `float` field `time` in the ROS message.
 The values represent the number of seconds (typically between 0.0 and 0.1) before the end of the scan, which is given in the `header.stamp` field.
 To get a per-point timestamp, we have to subtract the per-point `time` value from the value obtained from the `header.stamp` field.
 
 ### Hesai-like
-For Hesai-like timestamps, the timestamp is stored in the `double` field `timestamp` in the ROS message.
+
+For Hesai-like timestamps, the timestamp is stored in the `float64` field `timestamp` in the ROS message.
 The values represent the number of seconds in epoch time.
 This is the easest case as the timestamp is already in a 8-byte representation and we just need to multiply the per-point `timestamp` value by 1e9 to obtain nanoseconds and convert it to an `int64` datatype.
 
-----------------
+---
+
 Note that we haven't tested the bridge with different lidars, which might need special treatment due to different timestamp representations.
 To figure out how what exactly your ROS messages represent, you will need to investigate the driver code or the datasheet of the lidar.

--- a/package.xml
+++ b/package.xml
@@ -2,13 +2,14 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>libpointmatcher_ros</name>
-  <version>0.0.1</version>
+  <version>2.1.0</version>
   <description>A bridge between libpointmatcher and ROS</description>
   <maintainer email="simon-pierre.deschenes.1@ulaval.ca">Simon-Pierre Deschenes</maintainer>
+  <maintainer email="matej.boxan@norlab.ulaval.ca">Matej Boxan</maintainer>
   <license>BSD-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
+
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>nav_msgs</depend>

--- a/src/PointMatcher_ROS.cpp
+++ b/src/PointMatcher_ROS.cpp
@@ -206,8 +206,9 @@ typename PointMatcher<T>::DataPoints PointMatcher_ROS::rosMsgToPointMatcherCloud
 					const uint8_t *dataPtr(&rosMsg.data[0] + rosMsg.row_step * y);
 					for (size_t x(0); x < rosMsg.width; ++x)
 					{
-						const float time(*reinterpret_cast<const float *>(dataPtr + it->offset)); // Velodyne timestamp is 4 bytes
-						timeView(0, pointIdx) = scanTime + (int64_t)(time * 1e9);				 // Convert to nanoseconds
+						const float time(*reinterpret_cast<const float *>(dataPtr + it->offset)); // Leishen timestamp is 4 bytes
+						// Convert to nanoseconds and subtract from scan time, which refers to the scan end.
+						timeView(0, pointIdx) = scanTime - (int64_t)(time * 1e9);
 						dataPtr += rosMsg.point_step;
 						pointIdx += 1;
 					}
@@ -300,7 +301,7 @@ typename PointMatcher<T>::DataPoints PointMatcher_ROS::rosMsgToPointMatcherCloud
 			}
 		}
 	}
-	
+
 	return cloud;
 }
 

--- a/src/PointMatcher_ROS.cpp
+++ b/src/PointMatcher_ROS.cpp
@@ -56,22 +56,30 @@ typename PointMatcher<T>::DataPoints PointMatcher_ROS::rosMsgToPointMatcherCloud
 			isFeature.push_back(false);
 			fieldTypes.push_back(PM_types::DESCRIPTOR);
 		}
-		else if((it + 1) != rosMsg.fields.end() && ends_with(name, "_splitTime_high32") && ends_with(((it + 1)->name), "_splitTime_low32"))
+		else if ((it + 1) != rosMsg.fields.end() && ends_with(name, "_splitTime_high32") && ends_with(((it + 1)->name), "_splitTime_low32"))
 		{
-			// time extraction
-			std::string startingName = name;
-			erase_last(startingName, "_splitTime_high32");
-			const std::string beginning = startingName;
-
-			timeLabels.push_back(Label(beginning, 1));
+			// legacy time extraction
 			it += 1;
+			timeLabels.push_back(Label("time", 1)); // libpointmatcher Time field name is "time"
+			isFeature.push_back(false);
 			isFeature.push_back(false);
 			fieldTypes.push_back(PM_types::TIME);
 			fieldTypes.push_back(PM_types::TIME);
 		}
-		else if(name == "time")
+		// Process time information
+		else if (name == "time" || name == "t" || name == "timestamp")
 		{
-			timeLabels.push_back(Label(name, count));
+			switch (it->datatype)
+			{
+			case 6:
+			case 7:
+			case 8:
+				break;
+			default:
+				throw std::runtime_error("Unknown time field type. Field name: " + name + " datatype: " + std::to_string(unsigned(it->datatype)));
+			}
+
+			timeLabels.push_back(Label("time", count)); // libpointmatcher Time field name is "time"
 			isFeature.push_back(false);
 			fieldTypes.push_back(PM_types::TIME);
 		}
@@ -131,35 +139,25 @@ typename PointMatcher<T>::DataPoints PointMatcher_ROS::rosMsgToPointMatcherCloud
 				}
 			}
 		}
-		else if(ends_with(it->name, "_splitTime_high32") || ends_with(it->name, "_splitTime_low32") || it->name == "time")
+		// legacy libpointmatcher time fields
+		else if (ends_with(it->name, "_splitTime_high32") || ends_with(it->name, "_splitTime_low32"))
 		{
-			std::string startingName = it->name;
-			bool isHigh = false;
-			if(ends_with(it->name, "_splitTime_high32"))
-			{
-				erase_last(startingName, "_splitTime_high32");
-				isHigh = true;
-			}
-			if(ends_with(it->name, "_splitTime_low32"))
-			{
-				erase_last(startingName, "_splitTime_low32");
-			}
-
-			TimeView timeView(cloud.getTimeViewByName(startingName));
+			bool isHigh = ends_with(it->name, "_splitTime_high32");
+			TimeView timeView(cloud.getTimeViewByName("time"));
 
 			int ptId(0);
 			const size_t count(std::max<size_t>(it->count, 1));
-			for(size_t y(0); y < rosMsg.height; ++y)
+			for (size_t y(0); y < rosMsg.height; ++y)
 			{
-				const uint8_t* dataPtr(&rosMsg.data[0] + rosMsg.row_step * y);
-				for(size_t x(0); x < rosMsg.width; ++x)
+				const uint8_t *dataPtr(&rosMsg.data[0] + rosMsg.row_step * y);
+				for (size_t x(0); x < rosMsg.width; ++x)
 				{
-					const uint8_t* fPtr(dataPtr + it->offset);
-					for(unsigned dim(0); dim < count; ++dim)
+					const uint8_t *fPtr(dataPtr + it->offset);
+					for (unsigned dim(0); dim < count; ++dim)
 					{
-						if(isHigh)
+						if (isHigh)
 						{
-							const uint32_t high32 = *reinterpret_cast<const uint32_t*>(fPtr);
+							const uint32_t high32 = *reinterpret_cast<const uint32_t *>(fPtr);
 							const uint32_t low32 = uint32_t(timeView(dim, ptId));
 							timeView(dim, ptId) = (((uint64_t)high32) << 32) | ((uint64_t)low32);
 						}
@@ -175,11 +173,69 @@ typename PointMatcher<T>::DataPoints PointMatcher_ROS::rosMsgToPointMatcherCloud
 					}
 				}
 			}
-
+		}
+		else if (it->name == "time" || it->name == "t" || it->name == "timestamp")
+		{
+			int pointIdx;
+			TimeView timeView(cloud.getTimeViewByName("time"));
+			switch (it->datatype)
+			{
+			case 6:
+			{
+				pointIdx = 0;
+				int64_t scanTime = 1e9 * rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec;
+				for (size_t y(0); y < rosMsg.height; ++y)
+				{
+					const uint8_t *dataPtr(&rosMsg.data[0] + rosMsg.row_step * y);
+					for (size_t x(0); x < rosMsg.width; ++x)
+					{
+						const uint32_t time(*reinterpret_cast<const uint32_t *>(dataPtr + it->offset)); // Ouster timestamp is 4 bytes
+						timeView(0, pointIdx) = scanTime + (int64_t)time;							   // Lpm timestamp is 8 bytes
+						dataPtr += rosMsg.point_step;
+						pointIdx += 1;
+					}
+				}
+				break;
+			}
+			case 7:
+			{
+				pointIdx = 0;
+				int64_t scanTime = 1e9 * rosMsg.header.stamp.sec + rosMsg.header.stamp.nanosec;
+				for (size_t y(0); y < rosMsg.height; ++y)
+				{
+					const uint8_t *dataPtr(&rosMsg.data[0] + rosMsg.row_step * y);
+					for (size_t x(0); x < rosMsg.width; ++x)
+					{
+						const float time(*reinterpret_cast<const float *>(dataPtr + it->offset)); // Velodyne timestamp is 4 bytes
+						timeView(0, pointIdx) = scanTime + (int64_t)(time * 1e9);				 // Convert to nanoseconds
+						dataPtr += rosMsg.point_step;
+						pointIdx += 1;
+					}
+				}
+				break;
+			}
+			case 8:
+			{
+				pointIdx = 0;
+				for (size_t y(0); y < rosMsg.height; ++y)
+				{
+					const uint8_t *dataPtr(&rosMsg.data[0] + rosMsg.row_step * y);
+					for (size_t x(0); x < rosMsg.width; ++x)
+					{
+						const double time(*reinterpret_cast<const double *>(dataPtr + it->offset)); // Hesai timestamp is FLOAT64 = 8 bytes
+						timeView(0, pointIdx) = (int64_t)(time * 1e9);							  // Convert to nanoseconds
+						dataPtr += rosMsg.point_step;
+						pointIdx += 1;
+					}
+				}
+				break;
+			}
+			default:
+				throw std::runtime_error("Unknown time field type. Field name: " + it->name + " datatype: " + std::to_string(unsigned(it->datatype)));
+			}
 		}
 		else
 		{
-
 			// get view for editing data
 			View view(
 					(it->name == "normal_x") ? cloud.getDescriptorRowViewByName("normals", 0) :
@@ -326,6 +382,8 @@ typename PointMatcher<T>::DataPoints PointMatcher_ROS::rosMsgToPointMatcherCloud
 			is(0, i) = intensities[i];
 		}
 	}
+
+	// TODO add support for time fields
 
 	return cloud;
 }


### PR DESCRIPTION
The time field from ROS messages is always converted to the libpointmatcher "time" field of int64. The code that handles the conversion from different lidar types was originally located in the `pointcloud_motion_deskew` package.

Tested on:

- Ouster-like lidar (RS-32)
- Leishen-like lidar (LS-128)
- Hesai-like lidar (RS-128)

It is possible that the bridge will need to change drastically in the future with more added lidars.
The tested lidars differ not only in how they represent a per-point time but also at what point in time the `header.stamp` field points to. See the README file for a more detailed explanation.